### PR TITLE
New Feature - git_batch_puller

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,32 @@ gitutils-cherry-pick
 
 # Demo:
 
+## `gitutils-batch-pull`
+```
+This script will update all git repositories in the current directory.
+
+It will only check directories one level down
+and assumes there are no git repositories nested within sub-directories.
+
+Press 'Y' or 'Enter' to continue, or any other key to exit.
+y
+✅ Successfully pulled latest changes in ./gdoc-summaries
+Output for ./gdoc-summaries:
+Already up to date.
+
+🤔 Skipping ./gitutils-cli: Not on main or master branch.
+
+✅ Successfully pulled latest changes in ./jira-ticketer
+Output for ./jira-ticketer:
+Already up to date.
+
+✅ Successfully pulled latest changes in ./django
+Output for ./django:
+Already up to date.
+
+🚀 git batch pull completed.
+```
+
 ## `gitutils-merge`
 
 Safely handles conflicts:

--- a/cli/git_batch_puller.py
+++ b/cli/git_batch_puller.py
@@ -1,0 +1,79 @@
+"""Safely keep all your branches up to date with Remote"""
+
+import os
+import subprocess
+
+
+def is_git_directory(path: str) -> bool:
+    """Check if the path is a git repository."""
+    try:
+        subprocess.check_output(["git", "-C", path, "status"], stderr=subprocess.STDOUT)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def get_current_branch(path: str) -> str:
+    """Get the current branch name of a git repository."""
+    try:
+        branch = (
+            subprocess.check_output(
+                ["git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD"],
+                stderr=subprocess.STDOUT,
+            )
+            .strip()
+            .decode("utf-8")
+        )
+        return branch
+    except subprocess.CalledProcessError:
+        return None
+
+
+def git_pull(path):
+    """Perform a git pull in the given directory."""
+    try:
+        # Execute git pull and capture output
+        output = subprocess.check_output(
+            ["git", "-C", path, "pull"], stderr=subprocess.STDOUT
+        )
+        print(f"✅ Successfully pulled latest changes in {path}")
+        print(f"Output for {path}:\n{output.decode('utf-8')}")
+    except subprocess.CalledProcessError as e:
+        print(f"🤔 Failed to pull latest changes in {path}: {e}\n")
+
+
+def git_batch_puller():
+    """Main entrypoint to the git batch puller"""
+
+    # Display helper text and ask for confirmation
+    print("This script will update all git repositories in the current directory.")
+    print("\nIt will only check directories one level down")
+    print("and assumes there are no git repositories nested within sub-directories.")
+    print("\nPress 'Y' or 'Enter' to continue, or any other key to exit.")
+    confirmation = input().strip().lower()
+    if confirmation != "" and confirmation != "y":
+        print("Exiting script.")
+        exit()
+
+    # Iterate through subdirectories
+    items = os.listdir(".")
+    for item in items:
+        full_path = os.path.join(".", item)
+
+        # Check if it's a directory
+        if os.path.isdir(full_path):
+            # Check if it's a git repository
+            if is_git_directory(full_path):
+                branch = get_current_branch(full_path)
+                if branch in ["main", "master"]:
+                    git_pull(full_path)
+                else:
+                    print(f"🤔 Skipping {full_path}: Not on main or master branch.\n")
+            else:
+                print(f"🤔 Skipping {full_path}: Not a git repository.\n")
+
+    print("🚀 git batch pull completed.")
+
+
+if __name__ == "__main__":
+    git_batch_puller()

--- a/cli/tests/test_git_batch_puller.py
+++ b/cli/tests/test_git_batch_puller.py
@@ -1,0 +1,102 @@
+import io
+import os
+import subprocess
+import sys
+import unittest
+from unittest.mock import patch
+
+from cli import git_batch_puller
+
+
+class TestGitFunctions(unittest.TestCase):
+
+    @patch("subprocess.check_output")
+    def test_is_git_directory_true(self, mock_check_output):
+        # Setup mock to simulate success
+        mock_check_output.return_value = b"Success"
+
+        # Call the function under test
+        result = git_batch_puller.is_git_directory("/fake/path")
+
+        # Assert the expected outcome
+        self.assertTrue(result)
+        mock_check_output.assert_called_with(
+            ["git", "-C", "/fake/path", "status"], stderr=subprocess.STDOUT
+        )
+
+    @patch("subprocess.check_output")
+    def test_is_git_directory_false(self, mock_check_output):
+        # Setup mock to simulate failure
+        mock_check_output.side_effect = subprocess.CalledProcessError(128, "cmd")
+
+        # Call the function under test
+        result = git_batch_puller.is_git_directory("/fake/path")
+
+        # Assert the expected outcome
+        self.assertFalse(result)
+        mock_check_output.assert_called_with(
+            ["git", "-C", "/fake/path", "status"], stderr=subprocess.STDOUT
+        )
+
+    @patch("subprocess.check_output")
+    def test_get_current_branch(self, mock_check_output):
+        # Setup mock to simulate success
+        mock_check_output.return_value = b"main\n"
+
+        # Call the function under test
+        result = git_batch_puller.get_current_branch("/fake/path")
+
+        # Assert the expected outcome
+        self.assertEqual(result, "main")
+        mock_check_output.assert_called_with(
+            ["git", "-C", "/fake/path", "rev-parse", "--abbrev-ref", "HEAD"],
+            stderr=subprocess.STDOUT,
+        )
+
+    @patch("subprocess.check_output")
+    def test_git_pull_success(self, mock_check_output):
+        # Setup mock to simulate success
+        mock_check_output.return_value = b"Successful pull\n"
+
+        # Call the function under test
+        git_batch_puller.git_pull("/fake/path")
+
+        # Assert the expected outcome
+        mock_check_output.assert_called_with(
+            ["git", "-C", "/fake/path", "pull"], stderr=subprocess.STDOUT
+        )
+
+    @patch("os.listdir")
+    @patch("os.path.isdir")
+    @patch("cli.git_batch_puller.is_git_directory")
+    @patch("cli.git_batch_puller.get_current_branch")
+    @patch("cli.git_batch_puller.git_pull")
+    def test_git_batch_puller(
+        self,
+        mock_git_pull,
+        mock_get_current_branch,
+        mock_is_git_directory,
+        mock_isdir,
+        mock_listdir,
+    ):
+        # Setup mocks
+        mock_listdir.return_value = ["repo1", "not_a_repo"]
+        mock_isdir.side_effect = [True, False]
+        mock_is_git_directory.return_value = True
+        mock_get_current_branch.return_value = "main"
+
+        # Redirect stdin to simulate user input using StringIO
+        with io.StringIO("\n") as inputs:
+            sys.stdin = inputs
+
+            # Call the function under test
+            git_batch_puller.git_batch_puller()
+
+        # Assert the expected outcomes
+        mock_is_git_directory.assert_called_with(os.path.join(".", "repo1"))
+        mock_get_current_branch.assert_called_with(os.path.join(".", "repo1"))
+        mock_git_pull.assert_called_once_with(os.path.join(".", "repo1"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,18 @@
 """
 Generic setup for this python package
 """
+
 from setuptools import find_packages, setup
 
 setup(
     name="gitutils-cli",
-    version="0.5.01",
+    version="0.6.00",
     packages=find_packages(),
     entry_points={
         "console_scripts": [
             "gitutils-merge=cli.git_batch_merger:git_batch_merger",
             "gitutils-cherry-pick=cli.git_batch_cherry_picker:git_batch_cherry_picker",
+            "gitutils-batch-pull=cli.git_batch_puller:git_batch_puller",
         ],
     },
 )


### PR DESCRIPTION
Cool new feature that I wanted. I was irritated that my local code searches kept getting out of date. This should solve that! 👍 

Tested with unit tests and locally. Here's a sample output:

```
python -m gitutils-cli.cli.git_batch_puller

This script will update all git repositories in the current directory.

It will only check directories one level down
and assumes there are no git repositories nested within sub-directories.

Press 'Y' or 'Enter' to continue, or any other key to exit.
y
✅ Successfully pulled latest changes in ./gdoc-summaries
Output for ./gdoc-summaries:
Already up to date.

🤔 Skipping ./gitutils-cli: Not on main or master branch.
✅ Successfully pulled latest changes in ./jira-ticketer
Output for ./jira-ticketer:
Already up to date.

✅ Successfully pulled latest changes in ./django
Output for ./django:
Already up to date.

🚀 git batch pull completed.
```